### PR TITLE
CXXFLAGS の -D オプションの typo を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=`libusb-config --cflags` -g -Wall -DNDEUBG
+CXXFLAGS=`libusb-config --cflags` -g -Wall -DNDEBUG
 LDFLAGS=`libusb-config --libs` -g
 
 ifeq ($(wildcard .depend),.depend)


### PR DESCRIPTION
NDEBUG マクロが定義されず、デバッグ出力が常に有効になっていたと思われる。