### PR TITLE
usb_set_configuration(), usb_claim_interface() の呼び出しを追加

### DIFF
--- a/piecedev.cpp
+++ b/piecedev.cpp
@@ -50,6 +50,7 @@ UsbDevHandle::UsbDevHandle()
 					throw "open failed";
 
 				usb_dev_ = udev;
+				usb_config_ = dev->config;
 				return;
 			}
 		}
@@ -66,6 +67,14 @@ UsbDevHandle::~UsbDevHandle()
 Device::Device()
 	:mblk_adr_(pffs_top_)
 {
+	usb_config_descriptor *config = usb_dev_.config();
+
+	if ( ::usb_set_configuration( usb_dev_, config->bConfigurationValue ) < 0 )
+		throw ::usb_strerror();
+
+	if ( ::usb_claim_interface( usb_dev_, config->interface->altsetting->bInterfaceNumber ) < 0 )
+		throw ::usb_strerror();
+
 	readVersion();
 }
 

--- a/piecedev.h
+++ b/piecedev.h
@@ -10,11 +10,13 @@ namespace piece {
 
 class UsbDevHandle {
 	usb_dev_handle *usb_dev_;
+	usb_config_descriptor *usb_config_;
 
 public:
 	UsbDevHandle();
 	~UsbDevHandle();
 	operator usb_dev_handle *() const { return usb_dev_; }
+	usb_config_descriptor *config() const { return usb_config_; }
 };
 
 class Device {


### PR DESCRIPTION
issue https://github.com/zurachu/isd_for_linux/issues/5

参考 http://penguin.tantin.jp/hard/libusbについて.html#d9cd4039

https://github.com/libusb/libusb/blob/master/libusb/os/darwin_usb.c#L201
より、少なくとも MacOS(Darwin) 環境においては usb_set_configuration() または usb_claim_interface() を呼ばないとエンドポイントからパイプの参照への対応を検索するループに入ってなかったことになる。

-s オプション（アップロード）以外は動くようになった。