### PR TITLE
libusb-1.0のヘッダファイルを検索する場所を追加しました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-I/usr/local/include/libusb-1.0 -g -Wall -DNDEBUG
+CXXFLAGS=-I/usr/local/include/libusb-1.0 -I/usr/include/libusb-1.0 -g -Wall -DNDEBUG
 LDFLAGS=-lusb-1.0 -g
 
 ifeq ($(wildcard .depend),.depend)


### PR DESCRIPTION
use_only_libusb-1.0版も、Linuxで問題なく動きました。
ただ、ビルド時にエラーが出たので、Makefileを変更しました。

Debianでは、libusb-1.0-0-devパッケージをインストールすると、libusb.hは/usr/include/libusb-1.0/に入るようです。
元のMakefileでは、-I/usr/local/include/libusb-1.0が指定されていたので、Debianではビルド時にエラーになりました。
![screenshot from 2018-01-26 09-28-49](https://user-images.githubusercontent.com/18512546/35420445-dc2a636a-0280-11e8-9025-7c519a83735d.png)

そこで、CXXFLAGSに-I/usr/include/libusb-1.0を追加した所、問題なくビルド出来て、実行出来るようになりました。
動作検証に使ったシェルスクリプトを添付します。
[kensyou.zip](https://github.com/zurachu/isd_for_linux/files/1666229/kensyou.zip)
